### PR TITLE
Allow 'system' as theme preference

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -50,6 +50,8 @@ export function useTheme() {
     if (theme === 'light') {
       setThemeMode('dark')
     } else if (theme === 'dark') {
+      setThemeMode('system')
+    } else if (theme === 'system') {
       setThemeMode('light')
     } else {
       setThemeMode(isDark ? 'light' : 'dark')


### PR DESCRIPTION
If we touch the theme from the button at the top right, we cannot leave it as "System" which is default before the first interaction.
This commit adds "System" option back when user changes theme.